### PR TITLE
ci: add GitHub Actions workflow 'Test'

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CI: true
+  DOCKER_BUILDKIT: 1
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - run: ./build-all.sh

--- a/Dockerfile.32bit
+++ b/Dockerfile.32bit
@@ -14,7 +14,7 @@ ENV PATH /system/bin
 SHELL ["/system/bin/sh", "-c"]
 
 # Bootstrapping Termux environment.
-ADD https://dl.bintray.com/termux/bootstrap/bootstrap-i686-v33.zip /data/data/com.termux/files/bootstrap.zip
+ADD https://dl.bintray.com/termux/bootstrap/bootstrap-i686-v34.zip /data/data/com.termux/files/bootstrap.zip
 COPY /system /system
 RUN /system/setup-termux.sh
 

--- a/Dockerfile.32bit
+++ b/Dockerfile.32bit
@@ -14,7 +14,7 @@ ENV PATH /system/bin
 SHELL ["/system/bin/sh", "-c"]
 
 # Bootstrapping Termux environment.
-ADD https://dl.bintray.com/termux/bootstrap/bootstrap-i686-v34.zip /data/data/com.termux/files/bootstrap.zip
+ADD https://dl.bintray.com/termux/bootstrap/bootstrap-i686-v36.zip /data/data/com.termux/files/bootstrap.zip
 COPY /system /system
 RUN /system/setup-termux.sh
 

--- a/Dockerfile.64bit
+++ b/Dockerfile.64bit
@@ -14,7 +14,7 @@ ENV PATH /system/bin
 SHELL ["/system/bin/sh", "-c"]
 
 # Bootstrapping Termux environment.
-ADD https://dl.bintray.com/termux/bootstrap/bootstrap-x86_64-v34.zip /data/data/com.termux/files/bootstrap.zip
+ADD https://dl.bintray.com/termux/bootstrap/bootstrap-x86_64-v36.zip /data/data/com.termux/files/bootstrap.zip
 COPY /system /system
 RUN /system/setup-termux.sh
 

--- a/Dockerfile.64bit
+++ b/Dockerfile.64bit
@@ -14,7 +14,7 @@ ENV PATH /system/bin
 SHELL ["/system/bin/sh", "-c"]
 
 # Bootstrapping Termux environment.
-ADD https://dl.bintray.com/termux/bootstrap/bootstrap-x86_64-v33.zip /data/data/com.termux/files/bootstrap.zip
+ADD https://dl.bintray.com/termux/bootstrap/bootstrap-x86_64-v34.zip /data/data/com.termux/files/bootstrap.zip
 COPY /system /system
 RUN /system/setup-termux.sh
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 OCI="docker"
 case $1 in
     -p|--podman) OCI="podman" ;;


### PR DESCRIPTION
This PR adds a minimal GitHub Actions workflow for testing the dockerfiles.

Bootstrap zipfiles for v33 are not available anymore, so I updated the dockerfiles for retrieving v36.

Currently, building fails in the last RUN step because of `Can't resolve 'its-pointless.termux-mirror.ml'`. See https://github.com/umarcor/termux-docker/runs/1898460996?check_suite_focus=true#step:3:3165.