### PR TITLE
Update: update-static-dns

### DIFF
--- a/system/arm/bin/update-static-dns
+++ b/system/arm/bin/update-static-dns
@@ -10,7 +10,7 @@ for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^
 
 	if [ -z "$ip_addr" ]; then
 		echo "Can't resolve '$host'." >&2
-		exit 1
+		continue
 	fi
 
 	echo "$ip_addr $host" | busybox tee -a /system/etc/hosts

--- a/system/x86/bin/update-static-dns
+++ b/system/x86/bin/update-static-dns
@@ -10,7 +10,7 @@ for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^
 
 	if [ -z "$ip_addr" ]; then
 		echo "Can't resolve '$host'." >&2
-		exit 1
+		continue
 	fi
 
 	echo "$ip_addr $host" | busybox tee -a /system/etc/hosts


### PR DESCRIPTION
Sometimes domain name in the loop fails to be resolved due to some reason, but other domain names in the loop can be resolved successfully. Exiting midway doesn't seem like a good choice in this script.