### PR TITLE
Enable building image for arm, update bootstrap and add some utilities

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         CPU_ARCH:
           - aarch64
+          - arm
           - i686
           - x86_64
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,13 @@ RUN busybox mkdir -p /data/data/com.termux/files && \
     busybox ln -s /data/data/com.termux/files/usr/bin /bin && \
     busybox ln -s /data/data/com.termux/files/usr/tmp /tmp
 
+# Link some utilities to busybox.
+# Some utilities in $PREFIX are actually a wrapper of the same binary
+# from /system/bin. See termux-tools/build.sh#L29.
+RUN for tool in df mount ping ping6 top umount; do \
+        busybox ln -s /system/bin/busybox /system/bin/$tool; \
+    done
+
 # Set ownership and file access modes:
 # * User content is owned by 1000:1000.
 # * Termux file modes are set only for user.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Running image:
 There a number of known issues which may not be resolved:
 
 * ARM containers may require a custom seccomp profile to remove restrictions from
-  `personality()` system call. Whereas Docker Hub contains prebuilt ARM image, it
-  is outdated and won't receive updates anymore.
+  `personality()` system call.
 
 * DNS: Docker image has to use a static DNS resolver through `/system/etc/hosts`.
   You can regenerate this file by editing `/system/etc/static-dns-hosts.txt` and


### PR DESCRIPTION
(1) Enable building image for arm. `/system/bin/busybox` is a statically-linked arm binary and will not use the `personality()` system call from bionic libc.
(2) Update bootstrap. `bootstrap-2021.11.06-r1` is an old one. A lot of packages such as `openssl` have been updated.
(3) Link some utilities to busybox. Some utilities in $PREFIX are actually a wrapper of the same binary from /system/bin. Link them to busybox to avoid `/system/bin/xxx: No such file or directory`.