### PR TITLE
Add support for user static DNS file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,9 @@ RUN echo "echo -e 'Updating static DNS:\n' && /system/bin/update-static-dns && e
     busybox ln -s /system/etc/static-dns-hosts.txt /data/data/com.termux/files/usr/etc/static-dns-hosts.txt
 
 # Create empty user static DNS cache (external bind)
-RUN busybox touch /data/data/com.termux/files/home/.docker/static-dns-hosts.txt && \
-    busybox chown 1000:1000 /data/data/com.termux/files/home/.docker/static-dns-hosts.txt
+RUN busybox mkdir -p /data/data/com.termux/files/home/.termux/termux-docker/ && \
+    busybox touch /data/data/com.termux/files/home/.termux/termux-docker/static-dns-hosts.txt && \
+    busybox chown 1000:1000 /data/data/com.termux/files/home/.termux/termux-docker/static-dns-hosts.txt
 
 # Update static DNS cache, install updates and cleanup when not building for arm.
 ENV PATH /data/data/com.termux/files/usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,10 @@ RUN echo "echo -e 'Updating static DNS:\n' && /system/bin/update-static-dns && e
     busybox ln -s /system/bin/update-static-dns /data/data/com.termux/files/usr/bin/update-static-dns && \
     busybox ln -s /system/etc/static-dns-hosts.txt /data/data/com.termux/files/usr/etc/static-dns-hosts.txt
 
+# Create empty user static DNS cache (external bind)
+RUN busybox touch /data/data/com.termux/files/home/.static-dns-hosts.txt && \
+    busybox chown 1000:1000 /data/data/com.termux/files/home/.static-dns-hosts.txt
+
 # Update static DNS cache, install updates and cleanup when not building for arm.
 ENV PATH /data/data/com.termux/files/usr/bin
 RUN if [ ${BOOTSTRAP_ARCH} == 'arm' ]; then exit; else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ RUN echo "echo -e 'Updating static DNS:\n' && /system/bin/update-static-dns && e
     busybox ln -s /system/etc/static-dns-hosts.txt /data/data/com.termux/files/usr/etc/static-dns-hosts.txt
 
 # Create empty user static DNS cache (external bind)
-RUN busybox touch /data/data/com.termux/files/home/.static-dns-hosts.txt && \
-    busybox chown 1000:1000 /data/data/com.termux/files/home/.static-dns-hosts.txt
+RUN busybox touch /data/data/com.termux/files/home/.docker/static-dns-hosts.txt && \
+    busybox chown 1000:1000 /data/data/com.termux/files/home/.docker/static-dns-hosts.txt
 
 # Update static DNS cache, install updates and cleanup when not building for arm.
 ENV PATH /data/data/com.termux/files/usr/bin

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ There a number of known issues which may not be resolved:
 
 * DNS: Docker image has to use a static DNS resolver through `/system/etc/hosts`.
   You can regenerate this file by editing `/system/etc/static-dns-hosts.txt` or
-  `/data/data/com.termux/files/home/.static-dns-hosts.txt` (for docker binds) and
+  `/data/data/com.termux/files/home/.docker/static-dns-hosts.txt` (aka
+  `~/.docker/static-dns-hosts.txt) (this is preferable for docker binds) and
   executing script `/system/bin/update-static-dns`.
 
 * When running certain multi threaded program in 32bit containers, the PIDs can 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ There a number of known issues which may not be resolved:
 * DNS: Docker image has to use a static DNS resolver through `/system/etc/hosts`.
   You can regenerate this file by editing `/system/etc/static-dns-hosts.txt` or
   `/data/data/com.termux/files/home/.docker/static-dns-hosts.txt` (aka
-  `~/.docker/static-dns-hosts.txt) (this is preferable for docker binds) and
+  `~/.docker/static-dns-hosts.txt`) (this is preferable for docker binds) and
   executing script `/system/bin/update-static-dns`.
 
 * When running certain multi threaded program in 32bit containers, the PIDs can 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ There a number of known issues which may not be resolved:
   `personality()` system call.
 
 * DNS: Docker image has to use a static DNS resolver through `/system/etc/hosts`.
-  You can regenerate this file by editing `/system/etc/static-dns-hosts.txt` and
+  You can regenerate this file by editing `/system/etc/static-dns-hosts.txt` or
+  `/data/data/com.termux/files/home/.static-dns-hosts.txt` (for docker binds) and
   executing script `/system/bin/update-static-dns`.
 
 * When running certain multi threaded program in 32bit containers, the PIDs can 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ There a number of known issues which may not be resolved:
 
 * DNS: Docker image has to use a static DNS resolver through `/system/etc/hosts`.
   You can regenerate this file by editing `/system/etc/static-dns-hosts.txt` or
-  `/data/data/com.termux/files/home/.docker/static-dns-hosts.txt` (aka
-  `~/.docker/static-dns-hosts.txt`) (this is preferable for docker binds) and
-  executing script `/system/bin/update-static-dns`.
+  `/data/data/com.termux/files/home/.termux/termux-docker/static-dns-hosts.txt` (aka
+  `~/.termux/termux-docker/static-dns-hosts.txt`) (this is preferable for docker binds)
+  and executing script `/system/bin/update-static-dns`.
 
 * When running certain multi threaded program in 32bit containers, the PIDs can 
   balloon and easily exceed libc's limit. The only way to fix this is to set 

--- a/system/arm/bin/update-static-dns
+++ b/system/arm/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then
@@ -23,7 +23,7 @@ if [[ $? != 0 ]]; then
 	exit
 fi
 # IPv6
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=aaaa "$host" 2001:4860:4860::8888 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/arm/bin/update-static-dns
+++ b/system/arm/bin/update-static-dns
@@ -23,7 +23,7 @@ if [[ $? != 0 ]]; then
 	exit
 fi
 # IPv6
-for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=aaaa "$host" 2001:4860:4860::8888 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/arm/bin/update-static-dns
+++ b/system/arm/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.termux/termux-docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then
@@ -23,7 +23,7 @@ if [[ $? != 0 ]]; then
 	exit
 fi
 # IPv6
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.termux/termux-docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=aaaa "$host" 2001:4860:4860::8888 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/arm/bin/update-static-dns
+++ b/system/arm/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/x86/bin/update-static-dns
+++ b/system/x86/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then
@@ -23,7 +23,7 @@ if [[ $? != 0 ]]; then
 	exit
 fi
 # IPv6
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=aaaa "$host" 2001:4860:4860::8888 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/x86/bin/update-static-dns
+++ b/system/x86/bin/update-static-dns
@@ -23,7 +23,7 @@ if [[ $? != 0 ]]; then
 	exit
 fi
 # IPv6
-for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=aaaa "$host" 2001:4860:4860::8888 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/x86/bin/update-static-dns
+++ b/system/x86/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.termux/termux-docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then
@@ -23,7 +23,7 @@ if [[ $? != 0 ]]; then
 	exit
 fi
 # IPv6
-for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.termux/termux-docker/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=aaaa "$host" 2001:4860:4860::8888 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then

--- a/system/x86/bin/update-static-dns
+++ b/system/x86/bin/update-static-dns
@@ -6,7 +6,7 @@ echo "127.0.0.1 localhost $(busybox hostname)" > /system/etc/hosts
 echo "::1 ip6-localhost" >> /system/etc/hosts
 
 # IPv4
-for host in $(busybox cat /system/etc/static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
+for host in $(busybox cat /system/etc/static-dns-hosts.txt /data/data/com.termux/files/home/.static-dns-hosts.txt | busybox grep -vE '^\s*#'); do
 	ip_addr=$(busybox nslookup -type=a "$host" 8.8.8.8 | busybox awk '/^Address: / { print $2 ; exit }')
 
 	if [ -z "$ip_addr" ]; then


### PR DESCRIPTION
Adds the file `/data/data/com.termux/files/home/.static-dns-hosts.txt` with empty content to bind to it externally with some user hosts. The script `update-static-dns` then uses the regular system wide static-dns-hosts.txt and the content of this file. The user can edit it inside the container, and/or bind it with an external file.