### PR TITLE
chore(generate): update termux-pacman mirror and bootstrap version format

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -64,8 +64,8 @@ case "${TERMUX_PACKAGE_MANAGER}" in
 		TERMUX_DOCKER__BOOTSTRAP_VERSION="2026.04.26-r1%2Bpacman.android-7"
 		TERMUX_DOCKER__BOOTSTRAP_SRCURL="https://github.com/termux-pacman/termux-packages/releases/download/bootstrap-${TERMUX_DOCKER__BOOTSTRAP_VERSION}/bootstrap-${TERMUX_ARCH}.zip"
 		declare -A REPO_BASE_URLS=(
-			["main"]="https://service.termux-pacman.dev/main"
-			["root"]="https://service.termux-pacman.dev/root"
+			["main"]="https://sync.termux-pacman.dev/main"
+			["root"]="https://sync.termux-pacman.dev/root"
 		)
 		;;
 	*)

--- a/generate.sh
+++ b/generate.sh
@@ -52,7 +52,7 @@ fi
 case "${TERMUX_PACKAGE_MANAGER}" in
 	apt)
 		TERMUX_DOCKER__IMAGE_NAME="termux/termux-docker"
-		TERMUX_DOCKER__BOOTSTRAP_VERSION="2026.04.05-r1%2Bapt.android-7"
+		TERMUX_DOCKER__BOOTSTRAP_VERSION="2026.04.26-r1%2Bapt.android-7"
 		TERMUX_DOCKER__BOOTSTRAP_SRCURL="https://github.com/termux/termux-packages/releases/download/bootstrap-${TERMUX_DOCKER__BOOTSTRAP_VERSION}/bootstrap-${TERMUX_ARCH}.zip"
 		declare -A REPO_BASE_URLS=(
 			["main"]="https://packages-cf.termux.dev/apt/termux-main/dists/stable/main"
@@ -61,7 +61,7 @@ case "${TERMUX_PACKAGE_MANAGER}" in
 		;;
 	pacman)
 		TERMUX_DOCKER__IMAGE_NAME="termux/termux-docker-pacman"
-		TERMUX_DOCKER__BOOTSTRAP_VERSION="2026.04.05-r1%2Bpacman-android-7"
+		TERMUX_DOCKER__BOOTSTRAP_VERSION="2026.04.26-r1%2Bpacman.android-7"
 		TERMUX_DOCKER__BOOTSTRAP_SRCURL="https://github.com/termux-pacman/termux-packages/releases/download/bootstrap-${TERMUX_DOCKER__BOOTSTRAP_VERSION}/bootstrap-${TERMUX_ARCH}.zip"
 		declare -A REPO_BASE_URLS=(
 			["main"]="https://service.termux-pacman.dev/main"


### PR DESCRIPTION
- After this PR https://github.com/termux-pacman/termux-packages/pull/402 the termux-pacman bootstrap version format now has a `.` symbol instead of the second `-` symbol, which has been done in order to make the format match that which termux-apt has had since https://github.com/termux/termux-packages/commit/83dc034a1b3eb63bd43c33a5f5fe749c49fa6bae, so termux-docker needs to be updated to match, otherwise an error will occur if the bootstrap version is bumped without updating the format.

- Bump both bootstrap versions at the same time to 2026.04.26, for consistency.

- Update to new termux-pacman mirror `sync.termux-pacman.dev` after this PR, since `service.termux-pacman.dev` is currently down: https://github.com/termux/termux-packages/pull/29464