### PR TITLE
enhance(ci): convert `latest` tag into multiplatform tag

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -70,11 +70,7 @@ jobs:
 
     - name: Push to Docker Hub
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'termux/termux-docker'
-      run: |
-        docker push ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:${{ env.TERMUX_ARCH }}
-        if [ ${{ env.TERMUX_ARCH }} = x86_64 ]; then
-          docker push ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:latest
-        fi
+      run: docker push ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:${{ env.TERMUX_ARCH }}
 
     - name: Export container as tar archive
       if: always()
@@ -94,3 +90,40 @@ jobs:
       with:
         name: termux-docker-${{ env.TERMUX_PACKAGE_MANAGER }}-${{ env.TERMUX_ARCH }}-${{ github.sha }}
         path: termux-docker-${{ env.TERMUX_PACKAGE_MANAGER }}-${{ env.TERMUX_ARCH }}.tar
+
+  multiplatform:
+    strategy:
+      matrix:
+        include:
+          - package-manager: apt
+          - package-manager: pacman
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'termux/termux-docker'
+    needs: generate
+    runs-on: ubuntu-24.04
+    steps:
+
+    - name: Set variables
+      run: |
+        if [ ${{ matrix.package-manager }} = apt ]; then
+          echo "TERMUX_DOCKER__IMAGE_NAME=termux/termux-docker" >> $GITHUB_ENV
+        elif [ ${{ matrix.package-manager }} = pacman ]; then
+          echo "TERMUX_DOCKER__IMAGE_NAME=termux/termux-docker-pacman" >> $GITHUB_ENV
+        fi
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: grimler
+        password: ${{ secrets.GRIMLER_DOCKER_TOKEN }}
+
+    - name: Create multiplatform tag
+      run: |
+        docker manifest create \
+          ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:latest \
+          ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:i686 \
+          ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:x86_64 \
+          ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:arm \
+          ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:aarch64
+
+    - name: Push multiplatform tag to Docker Hub
+      run: docker manifest push ${{ env.TERMUX_DOCKER__IMAGE_NAME }}:latest

--- a/README.md
+++ b/README.md
@@ -18,18 +18,20 @@ This will start interactive login shell. Everything will look like in a
 normal Termux installation.
 
 ```.sh
-docker run -it termux/termux-docker:latest
+docker run -it termux/termux-docker
 ```
 
-When using the tag `latest`, container will be 64 bit (x86_64 architecture).
+When using no tag, or the tag `latest`, the container will automatically
+match the device architecture.
 
-Other architecture can be installed using a different tags. Available
-tags:
+Other architectures can be installed using different tags.
+Available tags:
 
 - `aarch64`
 - `arm`
 - `i686`
-- `x86_64` (`latest`)
+- `x86_64`
+- `latest` (multiplatform)
 
 If architecture is not compatible with host, the additional setup will
 be needed. Read this document further to learn how you can run containers
@@ -72,7 +74,7 @@ docker run -it --security-opt seccomp:unconfined termux/termux-docker:aarch64
 Variant with custom build of Docker:
 
 > [!NOTE]
-> Example with Debian trixie `armhf` host and the `docker.io` package. Assumes that [`deb-src` URIs](https://wiki.debian.org/Packaging/SourcePackage?action=show&redirect=SourcePackage#With_apt-get_source) and the [`devscripts` package](https://wiki.debian.org/Packaging#Suggested_tools_to_create_an_environment_for_packaging) are already installed, and that the current user is a member of the `docker` group.
+> Example with Debian trixie and the `docker.io` package. Assumes that [`deb-src` URIs](https://wiki.debian.org/Packaging/SourcePackage?action=show&redirect=SourcePackage#With_apt-get_source) and the [`devscripts` package](https://wiki.debian.org/Packaging#Suggested_tools_to_create_an_environment_for_packaging) are already installed, and that the current user is a member of the `docker` group.
 
 ```.sh
 sudo apt build-dep docker.io
@@ -83,7 +85,7 @@ cd docker.io-*/
 DEB_BUILD_OPTIONS=nocheck debuild -b -uc -us
 rm ../golang*
 sudo apt install ../*.deb
-docker run -it termux/termux-docker:arm
+docker run -it termux/termux-docker
 ```
 
 You might then want to temporarily use `sudo apt-mark hold docker.io` to ensure the package is not automatically upgraded, causing termux-docker to stop working on the device in the future, but **not upgrading can be a security risk**. If using the patch, it is recommended to patch and recompile the Docker daemon after every upgrade.
@@ -96,7 +98,7 @@ command line.
 Example:
 
 ```.sh
-docker run -it --rm termux/termux-docker:latest bash -c "apt update && apt install -yq clang"
+docker run -it --rm termux/termux-docker bash -c "apt update && apt install -yq clang"
 ```
 
 ### Root shell
@@ -114,7 +116,7 @@ The provided images have 2 entry points:
 Usage example:
 
 ```.sh
-docker run -it --entrypoint /entrypoint_root.sh termux/termux-docker:latest
+docker run -it --entrypoint /entrypoint_root.sh termux/termux-docker
 ```
 
 ## Building image

--- a/generate.sh
+++ b/generate.sh
@@ -460,10 +460,3 @@ $SUDO $OCI ${OCI_ARG} \
 if [ "${1-}" = "publish" ]; then
 	$SUDO $OCI push "${TERMUX_DOCKER__IMAGE_NAME}:${TERMUX_ARCH}"
 fi
-
-if [ "${TERMUX_ARCH}" = "x86_64" ]; then
-	$SUDO $OCI tag "${TERMUX_DOCKER__IMAGE_NAME}:${TERMUX_ARCH}" "${TERMUX_DOCKER__IMAGE_NAME}:latest"
-	if [ "${1-}" = "publish" ]; then
-		$SUDO $OCI push "${TERMUX_DOCKER__IMAGE_NAME}:latest"
-	fi
-fi


### PR DESCRIPTION
- The `latest` tag will now automatically determine the architecture before downloading the appropriate image, instead of being hardcoded to a single architecture.

- This will allow the `docker run -it termux/termux-docker` command to work on non-x86_64 devices, without having to explicitly specify the `:aarch64` tag.

- No additional significant storage space will be used in the DockerHub account, and the preexisting four architecture-specific tags will remain usable, for backwards compatibility

- Upstream documentation:
  - https://docs.docker.com/build/building/multi-platform/
  - https://docs.docker.com/reference/cli/docker/manifest/

- Example in other distro's Docker image: https://hub.docker.com/layers/library/debian/trixie/images/

- Related: https://github.com/termux/proot-distro/issues/666#issuecomment-4472975579

- Live test of my technique to make sure it will work: https://github.com/users/robertkirkman/packages/container/package/termux-docker (`docker run -it gchr.io/robertkirkman/termux-docker`)