### PR TITLE
chore(README): termux.com -> termux.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Termux environment for Docker/Podman.
 
-A [Termux](https://termux.com) environment packaged into Docker image.
+A [Termux](https://termux.dev) environment packaged into Docker image.
 Environment doesn't have Android runtime components, so certain things will
 not be available (DalvikVM, OpenSLES, etc...).
 


### PR DESCRIPTION
- termux.com is no longer under the control of the administrators of the github.com/termux organization. it is now exclusively under the control of the administrators of the github.com/termux-play-store organization.
- Additionally, the administrators of the github.com/termux-play-store organization are no longer in control of the builds on https://f-droid.org/en/packages/com.termux/ , and the administrators of the github.com/termux organization are no longer in control of the builds on https://play.google.com/store/apps/details?id=com.termux .
- Logically, it can be concluded that at some point, either the original administrators of the github.com/termux organization lost control of the termux.com domain, or the original administrators of the termux.com domain lost control of the github.com/termux organization, resulting in outdated links that no longer make sense throughout the repositories of the github.com/termux organization.
- https://github.com/termux/termux-app/discussions/4000
- termux-docker is maintained in the github.com/termux organization and tracks the app distributed at https://f-droid.org/en/packages/com.termux/ . Currently, there is no plan to attempt to implement a termux-docker of Google Play Termux, but my point of view is that a spiritually Google Play termux-docker's defining characteristic would probably be to contain an `aosp-libs` package bumped to version 11.0.0 or greater, matching the minSdkVersion 30 of the Google Play Termux app. There is no opposition to anyone working on that if someone wants to, but the resulting `Dockerfile` and `generate.sh` for that would then logically belong most appropriately at the URL https://github.com/termux-play-store/termux-docker , rather than at https://github.com/termux/termux-docker .